### PR TITLE
Check if unzipped path has one root folder

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,7 +3,6 @@ from cloudevents.events import (
     PulsarBinding,
     EventAttributes,
     EventOutcome,
-    CEMessageMode,
 )
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
@@ -47,28 +46,46 @@ class EventListener:
 
         # Event data
         incoming_event_data = event.get_data()
+        destination = incoming_event_data["destination"]
 
-        self.log.info(f"Start handling of {subject}.")
+        self.log.info(f"Start handling of {destination}.")
 
-        validator = MeemooSIPValidator()
-        success, report = validator.validate(Path(subject))
+        unzipped_path = Path(destination)
+        root_folder = self._get_single_subfolder(unzipped_path)
 
+        # Shared cloudevents
         attributes = EventAttributes(
             source=APP_NAME,
             subject=subject,
             correlation_id=attributes["correlation_id"],
-            outcome=EventOutcome.SUCCESS,
         )
-
         outgoing_event_data = {
-            "outcome": success,
-            "validation_report": report,
-            "sip_path": incoming_event_data["destination"],
+            "outcome": "",
+            "validation_report": "",
+            "sip_path": "",
+            "message": ""
         }
+
+        if not root_folder:
+            # Failed because the validation logic did not run
+            attributes["outcome"] = EventOutcome.FAIL
+            outgoing_event_data["message"] = "There should be one single root folder in the ZIP file."
+
+        else:
+            validator = MeemooSIPValidator()
+            success, report = validator.validate(root_folder)
+
+            # Successful in the sense that it was possible to run the validation logic
+            attributes["outcome"] = EventOutcome.SUCCESS
+            outgoing_event_data["outcome"] = success  # Actual validation of the SIP
+            outgoing_event_data["validation_report"] = report
+            outgoing_event_data["sip_path"] = str(root_folder),
 
         outgoing_event = Event(attributes, outgoing_event_data)
 
-        self.pulsar_client.produce_event(topic=self.pulsar_config["producer_topic"], event=outgoing_event)
+        self.pulsar_client.produce_event(
+            topic=self.pulsar_config["producer_topic"], event=outgoing_event
+        )
 
     def start_listening(self):
         """
@@ -86,3 +103,12 @@ class EventListener:
                 self.pulsar_client.negative_acknowledge(msg)
 
         self.pulsar_client.close()
+
+    def _get_single_subfolder(self, unzipped_path: Path) -> Path | None:
+        try:
+            items = list(unzipped_path.iterdir())
+            if len(items) == 1 and items[0].is_dir():
+                return items[0]
+            return None
+        except Exception:
+            return None

--- a/app/app.py
+++ b/app/app.py
@@ -67,7 +67,7 @@ class EventListener:
             )
 
             outgoing_event_data = {
-                "outcome": "",
+                "is_valid": False,
                 "validation_report": "",
                 "sip_path": "",
                 "message": "There should be one single root folder in the ZIP file.",
@@ -86,10 +86,10 @@ class EventListener:
             )
 
             outgoing_event_data = {
-                "outcome": success,  # Actual validation of the SIP
+                "is_valid": success,
                 "validation_report": report,
                 "sip_path": str(root_folder),
-                "mesage": "",
+                "message": "The SIP has been validated",
             }
 
         outgoing_event = Event(outgoing_attributes, outgoing_event_data)

--- a/app/app.py
+++ b/app/app.py
@@ -54,12 +54,12 @@ class EventListener:
         root_folder = self._get_single_subfolder(unzipped_path)
 
         # Shared cloudevents
-        attributes = None
+        outgoing_attributes = None
         outgoing_event_data = {}
 
         if not root_folder:
             # Failed because the validation logic did not run
-            attributes = EventAttributes(
+            outgoing_attributes = EventAttributes(
                 source=APP_NAME,
                 subject=subject,
                 correlation_id=attributes["correlation_id"],
@@ -78,7 +78,7 @@ class EventListener:
             success, report = validator.validate(root_folder)
 
             # Successful in the sense that it was possible to run the validation logic
-            attributes = EventAttributes(
+            outgoing_attributes = EventAttributes(
                 source=APP_NAME,
                 subject=subject,
                 correlation_id=attributes["correlation_id"],
@@ -92,7 +92,7 @@ class EventListener:
                 "mesage": "",
             }
 
-        outgoing_event = Event(attributes, outgoing_event_data)
+        outgoing_event = Event(outgoing_attributes, outgoing_event_data)
 
         self.pulsar_client.produce_event(
             topic=self.pulsar_config["producer_topic"], event=outgoing_event

--- a/app/app.py
+++ b/app/app.py
@@ -54,32 +54,43 @@ class EventListener:
         root_folder = self._get_single_subfolder(unzipped_path)
 
         # Shared cloudevents
-        attributes = EventAttributes(
-            source=APP_NAME,
-            subject=subject,
-            correlation_id=attributes["correlation_id"],
-        )
-        outgoing_event_data = {
-            "outcome": "",
-            "validation_report": "",
-            "sip_path": "",
-            "message": ""
-        }
+        attributes = None
+        outgoing_event_data = {}
 
         if not root_folder:
             # Failed because the validation logic did not run
-            attributes["outcome"] = EventOutcome.FAIL
-            outgoing_event_data["message"] = "There should be one single root folder in the ZIP file."
+            attributes = EventAttributes(
+                source=APP_NAME,
+                subject=subject,
+                correlation_id=attributes["correlation_id"],
+                outcome=EventOutcome.FAIL,
+            )
+
+            outgoing_event_data = {
+                "outcome": "",
+                "validation_report": "",
+                "sip_path": "",
+                "message": "There should be one single root folder in the ZIP file.",
+            }
 
         else:
             validator = MeemooSIPValidator()
             success, report = validator.validate(root_folder)
 
             # Successful in the sense that it was possible to run the validation logic
-            attributes["outcome"] = EventOutcome.SUCCESS
-            outgoing_event_data["outcome"] = success  # Actual validation of the SIP
-            outgoing_event_data["validation_report"] = report
-            outgoing_event_data["sip_path"] = str(root_folder),
+            attributes = EventAttributes(
+                source=APP_NAME,
+                subject=subject,
+                correlation_id=attributes["correlation_id"],
+                outcome=EventOutcome.SUCCESS,
+            )
+
+            outgoing_event_data = {
+                "outcome": success,  # Actual validation of the SIP
+                "validation_report": report,
+                "sip_path": str(root_folder),
+                "mesage": "",
+            }
 
         outgoing_event = Event(attributes, outgoing_event_data)
 


### PR DESCRIPTION
Check if the unzipped folder contains a single folder, which is the root folder of the SIP. If there is no folder, more than one folder and/or one or more files are present, the actual validation logic will not run and a failed event will be sent out.

In case of success, pass the root folder of the SIP in the event instead of the unzipped folder.

Furthermore, the validation logic got the zip folder as input. This is incorrect, it should be the unzipped folder.

Also, run autoformat.